### PR TITLE
Fix nested markdown

### DIFF
--- a/cogs/telegram_cog.py
+++ b/cogs/telegram_cog.py
@@ -181,23 +181,7 @@ class TelegramCog(commands.Cog):
         if message.forward_from or message.forward_from_chat:
             forwarded_from = self.fetch_forwarded_from(message, prefer_username=self.prefer_telegram_usernames)
 
-        # TODO: Move the markdownifying to Message properties/methods
-        formatted_message = message.text
-        if message.entities:
-            offsets = []
-            characters_added = 0
-            for entity in message.entities:
-                offset = entity.offset + characters_added
-                if entity.offset in offsets:
-                    offset -= 2
-                length = entity.length
-                text_seq = formatted_message[offset:offset+length]
-                offsets.append(entity.offset)
-
-                markdowned = entity.markdown(text_seq)
-                formatted_message = formatted_message[:offset] + markdowned + formatted_message[offset+length:]
-                characters_added += len(markdowned) - len(text_seq)
-
+        formatted_message = message.text_formatted
         if forwarded_from is not None:
             formatted_message = f"**Forwarded from {forwarded_from}**\n\n{formatted_message}"
 

--- a/cogs/telegram_cog.py
+++ b/cogs/telegram_cog.py
@@ -177,10 +177,7 @@ class TelegramCog(commands.Cog):
         :param message: Channel post to format.
         :return: Channel post text changed to Discord compatible format.
         """
-        forwarded_from = None
-        if message.forward_from or message.forward_from_chat:
-            forwarded_from = self.fetch_forwarded_from(message, prefer_username=self.prefer_telegram_usernames)
-
+        forwarded_from = self.fetch_forwarded_from(message, prefer_username=self.prefer_telegram_usernames)
         formatted_message = message.text_formatted
         if forwarded_from is not None:
             formatted_message = f"**Forwarded from {forwarded_from}**\n\n{formatted_message}"

--- a/cogs/telegram_cog.py
+++ b/cogs/telegram_cog.py
@@ -181,13 +181,18 @@ class TelegramCog(commands.Cog):
         if message.forward_from or message.forward_from_chat:
             forwarded_from = self.fetch_forwarded_from(message, prefer_username=self.prefer_telegram_usernames)
 
+        # TODO: Move the markdownifying to Message properties/methods
         formatted_message = message.text
         if message.entities:
+            offsets = []
             characters_added = 0
             for entity in message.entities:
                 offset = entity.offset + characters_added
+                if entity.offset in offsets:
+                    offset -= 2
                 length = entity.length
                 text_seq = formatted_message[offset:offset+length]
+                offsets.append(entity.offset)
 
                 markdowned = entity.markdown(text_seq)
                 formatted_message = formatted_message[:offset] + markdowned + formatted_message[offset+length:]


### PR DESCRIPTION
Fixed nested markdown as mentioned in issue https://github.com/Visperi/GlasnostBot/issues/7.

Additionally made minor readability changes by moving text formatting to `telegram.Message` properties and removed redundant logic from method `format_channel_post`.