### PR TITLE
Add embed support

### DIFF
--- a/telegram/message.py
+++ b/telegram/message.py
@@ -123,6 +123,8 @@ class MessageEntity:
             return f"`{text}`"
         elif self.type == EntityType.Codeblock:
             return f"```\n{text}\n```"
+        elif self.type == EntityType.TextLink:
+            return f"[{text}]({self.url})"
         else:
             return text
 


### PR DESCRIPTION
Change forwarded messages to Discord embeds instead of plain text messages. This has advantage of supporting up to 4096 character messages (max length for also free Telegram), embed scaling for different monitor sizes and better control for sections, footers and other fields. Example of an embed send to Discord:

![example_embed](https://user-images.githubusercontent.com/25469124/210605565-1cb27791-ed68-4245-bb01-755415cdf06a.PNG)