### PR TITLE
Fix TextLink entities with schema in the text

### DIFF
--- a/telegram/message.py
+++ b/telegram/message.py
@@ -738,12 +738,12 @@ class Message(MaybeInaccessibleMessage):
     def _handle_reply_markup(self, value):
         self.reply_markup = InlineKeyboardMarkup(value)
 
-    def markdown(self, make_urls_to_hyperlink: bool = True, allow_hyperlink_text_schema: bool = False) -> Optional[str]:
+    def markdown(self, complete_partial_urls: bool = True, allow_hyperlink_text_schema: bool = False) -> Optional[str]:
         """
         Convert the message and its entities to Markdown.
 
-        :param make_urls_to_hyperlink: Make URLs in text format to hyperlinks with the original text. If a hyperlink
-                                       cannot be made, keep them in the original format.
+        :param complete_partial_urls: Make URLs in text format to hyperlinks with the original text if they are not
+                                      already complete URLs.
         :param allow_hyperlink_text_schema: Allow hyperlink texts to contain the URL schema. Some Markdown processors
                                             do not render hyperlinks properly when there is a URL schema in the
                                             hyperlink text. If False, such links are formatted as plain URLs instead.
@@ -766,7 +766,7 @@ class Message(MaybeInaccessibleMessage):
             entity_start = entity.offset * 2 + cumulative_offset
             entity_end = entity_start + entity.length * 2
             entity_text = utf16_bytes[entity_start:entity_end].decode("utf-16-le")
-            markdown, offset = entity.nested_markdown(entity_text, offset_group[1:], make_urls_to_hyperlink, allow_hyperlink_text_schema)
+            markdown, offset = entity.nested_markdown(entity_text, offset_group[1:], complete_partial_urls, allow_hyperlink_text_schema)
             utf16_bytes[entity_start:entity_end] = markdown.encode("utf-16-le")
             cumulative_offset += offset * 2
 

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -738,12 +738,15 @@ class Message(MaybeInaccessibleMessage):
     def _handle_reply_markup(self, value):
         self.reply_markup = InlineKeyboardMarkup(value)
 
-    def markdown(self, make_urls_to_hyperlink: bool = True) -> Optional[str]:
+    def markdown(self, make_urls_to_hyperlink: bool = True, allow_hyperlink_text_schema: bool = False) -> Optional[str]:
         """
         Convert the message and its entities to Markdown.
 
         :param make_urls_to_hyperlink: Make URLs in text format to hyperlinks with the original text. If a hyperlink
                                        cannot be made, keep them in the original format.
+        :param allow_hyperlink_text_schema: Allow hyperlink texts to contain the URL schema. Some Markdown processors
+                                            do not render hyperlinks properly when there is a URL schema in the
+                                            hyperlink text. If False, such links are formatted as plain URLs instead.
         :return: The message text content in Markdown syntax.
         """
         utf8_text = self.text_content
@@ -763,7 +766,7 @@ class Message(MaybeInaccessibleMessage):
             entity_start = entity.offset * 2 + cumulative_offset
             entity_end = entity_start + entity.length * 2
             entity_text = utf16_bytes[entity_start:entity_end].decode("utf-16-le")
-            markdown, offset = entity.nested_markdown(entity_text, offset_group[1:], make_urls_to_hyperlink)
+            markdown, offset = entity.nested_markdown(entity_text, offset_group[1:], make_urls_to_hyperlink, allow_hyperlink_text_schema)
             utf16_bytes[entity_start:entity_end] = markdown.encode("utf-16-le")
             cumulative_offset += offset * 2
 

--- a/telegram/message_entity.py
+++ b/telegram/message_entity.py
@@ -138,6 +138,20 @@ class MessageEntity:
         filled = tmp._replace(netloc=netloc, path=path)
         return str(urlunparse(filled))
 
+    @staticmethod
+    def text_is_url(text) -> bool:
+        """
+        Check if a text is a complete URL.
+
+        :param text: The text.
+        :return: True if the text is URL, False otherwise.
+        """
+        try:
+            result = urlparse(text)
+            return all([result.scheme, result.netloc])
+        except KeyError:
+            return False
+
     def markdown(self, text: str, make_url_to_hyperlink: bool) -> Tuple[str, int]:
         """
         Convert entity to Markdown syntax with given text.
@@ -209,7 +223,12 @@ class MessageEntity:
         if self.type == EntityType.Codeblock:
             before_text = before_text.format(self.language or "")
         elif self.type == EntityType.TextLink:
-            after_text = after_text.format(self.url)
+            if self.text_is_url(text):
+                markdown_syntax = markdowns[EntityType.Url]
+                before_text = markdown_syntax["before"]
+                after_text = markdown_syntax["after"]
+            else:
+                after_text = after_text.format(self.url)
         elif self.type == EntityType.Url and make_url_to_hyperlink:
             url = self._complete_url(text)
             if text != url:

--- a/telegram/message_entity.py
+++ b/telegram/message_entity.py
@@ -152,7 +152,7 @@ class MessageEntity:
         except KeyError:
             return False
 
-    def markdown(self, text: str, make_url_to_hyperlink: bool) -> Tuple[str, int]:
+    def markdown(self, text: str, make_url_to_hyperlink: bool, allow_hyperlink_text_schema: bool = False) -> Tuple[str, int]:
         """
         Convert entity to Markdown syntax with given text.
 
@@ -160,6 +160,9 @@ class MessageEntity:
         :param make_url_to_hyperlink: Make ``EntityType.Url`` entities to hyperlinks. The original text will not be
                                       modified. The original text is returned if the URL is already complete and a
                                       hyperlink cannot be made.
+        :param allow_hyperlink_text_schema: Allow hyperlink text to contain the URL schema. Some Markdown processors
+                                            do not render hyperlinks properly when there is a URL schema in the
+                                            hyperlink text. If False, such link is formatted as plain URL instead.
         :return: Given text converted to Entity Markdown syntax and the length increase compared to the original text.
         """
         if not self.type.supports_markdown:
@@ -223,7 +226,7 @@ class MessageEntity:
         if self.type == EntityType.Codeblock:
             before_text = before_text.format(self.language or "")
         elif self.type == EntityType.TextLink:
-            if self.text_is_url(text):
+            if not allow_hyperlink_text_schema and self.text_is_url(text):
                 markdown_syntax = markdowns[EntityType.Url]
                 before_text = markdown_syntax["before"]
                 after_text = markdown_syntax["after"]
@@ -238,19 +241,25 @@ class MessageEntity:
 
         return f"{before_text}{text}{after_text}", len(before_text) + len(after_text)
 
-    def nested_markdown(self, text: str, message_entities: List['MessageEntity'], make_urls_to_hyperlinks: bool):
+    def nested_markdown(self,
+                        text: str, message_entities: List['MessageEntity'],
+                        make_urls_to_hyperlinks: bool,
+                        allow_hyperlink_text_schema: bool = False):
         """
         Apply nested markdown to the message entity.
 
         :param text: Text to add the markdown for.
         :param message_entities: List of ``MessageEntity`` objects to combine with this message entity.
         :param make_urls_to_hyperlinks: Make bare text urls to hyperlinks.
+        :param allow_hyperlink_text_schema: Allow hyperlink text to contain the URL schema. Some Markdown processors
+                                            do not render hyperlinks properly when there is a URL schema in the
+                                            hyperlink text. If False, such link is formatted as plain URL instead.
         :return: The text with all given message entity markdowns applied and the length increase compared to
                  the original text.
         """
         output, cumulative_offset = self.markdown(text, make_urls_to_hyperlinks)
         for entity in message_entities:
-            output, added_offset = entity.markdown(output, make_urls_to_hyperlinks)
+            output, added_offset = entity.markdown(output, make_urls_to_hyperlinks, allow_hyperlink_text_schema)
             cumulative_offset += added_offset
 
         return output, cumulative_offset


### PR DESCRIPTION
Some Markdown processors don't allow hyperlinks with schema in the text. Forward such links as plain urls instead.